### PR TITLE
add odri support (wip)

### DIFF
--- a/pkgs/by-name/od/odri-control/package.nix
+++ b/pkgs/by-name/od/odri-control/package.nix
@@ -8,7 +8,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "odri";
+  pname = "odri-control";
   version = "1.0.1";
 
   src = fetchgit {

--- a/pkgs/by-name/od/odri-control/package.nix
+++ b/pkgs/by-name/od/odri-control/package.nix
@@ -5,7 +5,7 @@
   cmake,
   yaml-cpp,
   eigen,
-  odri-masterboard,
+  odri-masterboard-sdk,
   python312,
   python312Packages,
 }:
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     cmake
     yaml-cpp
     eigen
-    odri-masterboard
+    odri-masterboard-sdk
     python312Packages.eigenpy
     python312Packages.boost
     python312

--- a/pkgs/by-name/od/odri-control/package.nix
+++ b/pkgs/by-name/od/odri-control/package.nix
@@ -5,6 +5,9 @@
   cmake,
   yaml-cpp,
   eigen,
+  odri-masterboard,
+  python312,
+  python312Packages,
 }:
 
 stdenv.mkDerivation rec {
@@ -24,5 +27,9 @@ stdenv.mkDerivation rec {
     cmake
     yaml-cpp
     eigen
+    odri-masterboard
+    python312Packages.eigenpy
+    python312Packages.boost
+    python312
   ];
 }

--- a/pkgs/by-name/od/odri-control/package.nix
+++ b/pkgs/by-name/od/odri-control/package.nix
@@ -1,0 +1,27 @@
+{
+  fetchFromGitHub,
+  fetchgit,
+  stdenv,
+  cmake,
+  yaml-cpp,
+  eigen,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "odri";
+  version = "1.0.1";
+
+  src = fetchgit {
+    url = "https://github.com/open-dynamic-robot-initiative/odri_control_interface";
+    # repo = "odri_control_interface";
+    rev = "v${version}";
+    # sha256 = "sha256-jeZFgAW8C+UCeW+TtV1fNJZR7yuWcpiQnepsbkNanPg=";
+    hash = "sha256-NGsgrSyhD2fFTm/IqgdqXw7aMEwD7QSsPDhjDm+50qQ=";
+    fetchSubmodules = true;
+  };
+
+
+  nativeBuildInputs = [ cmake yaml-cpp eigen ];
+}
+
+

--- a/pkgs/by-name/od/odri-control/package.nix
+++ b/pkgs/by-name/od/odri-control/package.nix
@@ -20,8 +20,9 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
-
-  nativeBuildInputs = [ cmake yaml-cpp eigen ];
+  nativeBuildInputs = [
+    cmake
+    yaml-cpp
+    eigen
+  ];
 }
-
-

--- a/pkgs/by-name/od/odri-masterboard-sdk/package.nix
+++ b/pkgs/by-name/od/odri-masterboard-sdk/package.nix
@@ -8,7 +8,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "odri-masterboard";
+  pname = "odri-masterboard-sdk";
   version = "9388c843e569d5bd3cd836f442ddfef43c8a7528";
 
   src = fetchgit {

--- a/pkgs/by-name/od/odri-masterboard/package.nix
+++ b/pkgs/by-name/od/odri-masterboard/package.nix
@@ -3,18 +3,21 @@
   fetchgit,
   stdenv,
   cmake,
+  python312,
+  python312Packages,
 }:
 
 stdenv.mkDerivation rec {
   pname = "odri-masterboard";
-  version = "1.0.7";
+  version = "1c152c810dbb5e8c7bea0a3139b06e9d2286ad72";
 
   src = fetchgit {
-    url = "https://github.com/open-dynamic-robot-initiative/master-board";
+    #url = "https://github.com/open-dynamic-robot-initiative/master-board";
+    url = "https://github.com/gwennlbh/master-board";
     # repo = "odri_control_interface";
-    rev = "v${version}";
+    rev =version;
     # sha256 = "sha256-jeZFgAW8C+UCeW+TtV1fNJZR7yuWcpiQnepsbkNanPg=";
-    hash = "sha256-8Yw79we53PE9HHu2j95DR4PJi/MZVtunpFA2at7+4Uk=";
+    hash = "sha256-3vx3bOQkFnZXZ4jSh89Se7T8t6VpfL+JV3sVHz8+X78=";
     sparseCheckout = [
       "sdk/master_board_sdk"
     ];
@@ -23,5 +26,5 @@ stdenv.mkDerivation rec {
 
   sourceRoot = "${src.name}/sdk/master_board_sdk";
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake python312 python312Packages.boost ];
 }

--- a/pkgs/by-name/od/odri-masterboard/package.nix
+++ b/pkgs/by-name/od/odri-masterboard/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     #url = "https://github.com/open-dynamic-robot-initiative/master-board";
     url = "https://github.com/gwennlbh/master-board";
     # repo = "odri_control_interface";
-    rev =version;
+    rev = version;
     # sha256 = "sha256-jeZFgAW8C+UCeW+TtV1fNJZR7yuWcpiQnepsbkNanPg=";
     hash = "sha256-3vx3bOQkFnZXZ4jSh89Se7T8t6VpfL+JV3sVHz8+X78=";
     sparseCheckout = [
@@ -26,5 +26,9 @@ stdenv.mkDerivation rec {
 
   sourceRoot = "${src.name}/sdk/master_board_sdk";
 
-  nativeBuildInputs = [ cmake python312 python312Packages.boost ];
+  nativeBuildInputs = [
+    cmake
+    python312
+    python312Packages.boost
+  ];
 }

--- a/pkgs/by-name/od/odri-masterboard/package.nix
+++ b/pkgs/by-name/od/odri-masterboard/package.nix
@@ -1,0 +1,33 @@
+{
+  fetchFromGitHub,
+  fetchgit,
+  stdenv,
+  cmake,
+  yaml-cpp,
+  eigen,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "odri";
+  version = "1.0.1";
+
+  src = fetchgit {
+    url = "https://github.com/open-dynamic-robot-initiative/master-board";
+    # repo = "odri_control_interface";
+    rev = "v${version}";
+    # sha256 = "sha256-jeZFgAW8C+UCeW+TtV1fNJZR7yuWcpiQnepsbkNanPg=";
+    hash = "sha256-8Yw79we53PE9HHu2j95DR4PJi/MZVtunpFA2at7+4Uk=";
+    sparseCheckout = [
+      "sdk/master_board_sdk"
+    ];
+    fetchSubmodules = true;
+  };
+
+  prePatch = ''
+    cd sdk/master_board_sdk
+  '';
+
+  nativeBuildInputs = [ cmake yaml-cpp eigen ];
+}
+
+

--- a/pkgs/by-name/od/odri-masterboard/package.nix
+++ b/pkgs/by-name/od/odri-masterboard/package.nix
@@ -9,14 +9,11 @@
 
 stdenv.mkDerivation rec {
   pname = "odri-masterboard";
-  version = "1c152c810dbb5e8c7bea0a3139b06e9d2286ad72";
+  version = "9388c843e569d5bd3cd836f442ddfef43c8a7528";
 
   src = fetchgit {
-    #url = "https://github.com/open-dynamic-robot-initiative/master-board";
-    url = "https://github.com/gwennlbh/master-board";
-    # repo = "odri_control_interface";
+    url = "https://github.com/open-dynamic-robot-initiative/master-board";
     rev = version;
-    # sha256 = "sha256-jeZFgAW8C+UCeW+TtV1fNJZR7yuWcpiQnepsbkNanPg=";
     hash = "sha256-3vx3bOQkFnZXZ4jSh89Se7T8t6VpfL+JV3sVHz8+X78=";
     sparseCheckout = [
       "sdk/master_board_sdk"

--- a/pkgs/by-name/od/odri-masterboard/package.nix
+++ b/pkgs/by-name/od/odri-masterboard/package.nix
@@ -3,8 +3,6 @@
   fetchgit,
   stdenv,
   cmake,
-  yaml-cpp,
-  eigen,
 }:
 
 stdenv.mkDerivation rec {
@@ -23,11 +21,9 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
-  prePatch = ''
-    cd sdk/master_board_sdk
-  '';
+  sourceRoot = "${src.name}/sdk/master_board_sdk";
 
-  nativeBuildInputs = [ cmake yaml-cpp eigen ];
+  nativeBuildInputs = [ cmake ];
 }
 
 

--- a/pkgs/by-name/od/odri-masterboard/package.nix
+++ b/pkgs/by-name/od/odri-masterboard/package.nix
@@ -6,8 +6,8 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "odri";
-  version = "1.0.1";
+  pname = "odri-masterboard";
+  version = "1.0.7";
 
   src = fetchgit {
     url = "https://github.com/open-dynamic-robot-initiative/master-board";

--- a/pkgs/by-name/od/odri-masterboard/package.nix
+++ b/pkgs/by-name/od/odri-masterboard/package.nix
@@ -25,5 +25,3 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 }
-
-


### PR DESCRIPTION
- [ ] try to use fetchFromGitHub, fetchSubmodules [should work](https://github.com/NixOS/nixpkgs/pull/20518) since \*checks notes\* 2016, but does not init submodules, whereas fetchgit does
- [x] master-board
  - [x] discover missing libs (done?)
  - [x] fix compile errors (missing headers, but for like, cstdio???)
- [x] controls
  - [x] discover missing libs
  - [x] depends on master-board


